### PR TITLE
Test email protection options

### DIFF
--- a/_pages/council.md
+++ b/_pages/council.md
@@ -13,7 +13,7 @@ Chemical Crystallography
 Chemistry Research Laboratory
 12 Mansfield Road
 Oxford OX1 3TA
-E-mail: president@crystallography.org.uk
+[E-mail](president@crystallography.org.uk)
 
  
 ## Vice-President


### PR DESCRIPTION
Changed president email to link. The cloudflare protection in front of the site should obscure it from webscrapers.